### PR TITLE
Scrollable signposts

### DIFF
--- a/content-script.js
+++ b/content-script.js
@@ -24,6 +24,7 @@ const renderSignpost = (signpost) => {
     signpostBar.style.borderRadius = "4px";
     signpostBar.style.fontFamily = "sans-serif";
     signpostBar.style.overflow = "auto";
+    signpostBar.style.maxHeight = "50%"
     document.body.appendChild(signpostBar);
 
     signpostBar.innerHTML = `${logoHTML}${closeLinkHTML}`;

--- a/content-script.js
+++ b/content-script.js
@@ -23,6 +23,7 @@ const renderSignpost = (signpost) => {
     signpostBar.style.padding = "16px 16px 16px 40px";
     signpostBar.style.borderRadius = "4px";
     signpostBar.style.fontFamily = "sans-serif";
+    signpostBar.style.overflow = "auto";
     document.body.appendChild(signpostBar);
 
     signpostBar.innerHTML = `${logoHTML}${closeLinkHTML}`;


### PR DESCRIPTION
Hi,

First of all thanks for this great plugin!

When implementing signposts in one of our projects, I noticed that the overlay failed to handle large amount of signposts (>100 in our case). In this case, the overlay extends over the whole screen, but doesn't scroll together with the rest of the content. Because of this, only some signposts are shown and the bottom of the signpost list is never reachable.

To fix this, i suggest to add scrolling behavior to the overlay if the number of signposts exceeds the height of the view. I additionally changed the maxHeight of the overlay to 50%, but of course this change is optional and adding a scrollbar would also fix the issue if the full width is exceeded.

|--------|---------|
| Before | After |
|--------|---------|
|<img width="100%" src="https://github.com/user-attachments/assets/bacc1e30-e04a-4041-b457-8b2c7bcb80b6">|<img width="100%" src="https://github.com/user-attachments/assets/c21d5b8d-edd4-4d0e-b4c0-ca27539cf4a6">|

