### PR TITLE
Add support for rel=linkset

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -9,6 +9,7 @@ const signpostRelations = {
   "cite-as": "should be cited as",
   type: "is of the type described at",
   license: "is licensed according to",
+  linkset: "has a linkset at",
 };
 
 chrome.storage.session.setAccessLevel({


### PR DESCRIPTION
Currently, the plugin does not support typed-links pointing to a linkset (rel=linkset).
This PR adds this type to the list of displayed signposts.

Example:
We use linksets in our project AI4Wildlive https://wildlive.senckenberg.de: [Example page with signposting](https://wildlive.senckenberg.de/captureevent/wildlive/54a11e70930173b84f31)

Result with this PR:
![image](https://github.com/user-attachments/assets/f6decb4c-1de8-4fec-ae12-47cd449619e4)

(Tagging @jgrieb here as well)
